### PR TITLE
Restrict meson version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           sudo update-alternatives --remove-all go || true
           sudo update-alternatives --install /usr/bin/go go $(which go) 1
           go install honnef.co/go/tools/cmd/staticcheck@latest
-          sudo pip3 install meson
+          sudo pip3 install 'meson >=0.55, <0.60'
           echo '::set-output name=meson::'$(meson --version)
       - name: install uBPF
         run: |

--- a/docs/ndndpdk-depends.sh
+++ b/docs/ndndpdk-depends.sh
@@ -312,7 +312,7 @@ if [[ $DISTRO == bionic ]]; then
   $SUDO update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 fi
 curl -fsLS "${NDNDPDK_DL_PYPA_BOOTSTRAP}/get-pip.py" | $SUDO python
-$SUDO pip install -U meson pyelftools
+$SUDO pip install -U 'meson >=0.55, <0.60' pyelftools
 
 if [[ $GOVER != 0 ]]; then
   $SUDO rm -rf /usr/local/go


### PR DESCRIPTION
meson 0.60 started using thin archives for internal static libraries but DPDK's build system seems unable to handle them.

Installation fails with:
```
[399/2324] Generating drivers/rte_bus_vdev.pmd.c with a custom command
FAILED: drivers/rte_bus_vdev.pmd.c 
/usr/bin/python ../buildtools/gen-pmdinfo-cfile.py /root/dpdk-21.08/dpdk-21.08/build/buildtools ar /root/dpdk-21.08/dpdk-21.08/build/drivers/libtmp_rte_bus_vdev.a drivers/rte_bus_vdev.pmd.c /usr/bin/python ../buildtools/pmdinfogen.py elf
ar: `x' cannot be used on thin archives.
Traceback (most recent call last):
  File "../buildtools/gen-pmdinfo-cfile.py", line 17, in <module>
    run_ar("x")
  File "../buildtools/gen-pmdinfo-cfile.py", line 14, in <lambda>
    stdout=subprocess.PIPE, check=True, cwd=temp
  File "/usr/lib/python3.6/subprocess.py", line 438, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['ar', 'x', '/root/dpdk-21.08/dpdk-21.08/build/drivers/libtmp_rte_bus_vdev.a']' returned non-zero exit status 1.
```